### PR TITLE
Save Metadata on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,33 @@
 # retroflag-picase
-RetroFlag Pi-Case Safe Shutdown
+## RetroFlag Pi-Case+ Safe Shutdown
 
-Turn switch "SAFE SHUTDOWN" on PCB to ON.
+#### Turn switch "SAFE SHUTDOWN" on PCB to ON position.
+
+![Safe Shutdown Switch](http://retroflag.com/images/nespi_case+/safe_shutdown.jpg "Safe Shutdown Switch")
+
+Script will attempt to close a running emulator kindly and force close if it takes too long to respond. Then it will close EmulationStation kindly to save metadata before reset or shutdown.
 
 --------------------
 
 Example for RetroPie:
-1. Make sure internet connected.
-2. Make sure keyboard connected.
-3. Press F4 enter terminal.
+1. Make sure internet is connected.
+2. Make sure keyboard is connected.
+3. Press F4 to enter terminal.
 4. In the terminal, type the one-line command below(Case sensitive):
 
+```bash
 wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/install.sh" | sudo bash
+```
 
 --------------------
 
 Example for RecalBox:
-1. Make sure internet connected.
-2. Make sure keyboard connected.
-3. Press F4 first. And then press ALT-F2 enter termial.
+1. Make sure internet is connected.
+2. Make sure keyboard is connected.
+3. Press F4 first. Then press ALT-F2 to enter terminal.
 4. User:root Password:recalboxroot
 5. In the terminal, type the one-line command below(Case sensitive):
 
+```bash
 wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/recalbox_install.sh" | bash
+```

--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -60,10 +60,6 @@ def exit_es(exit_command, es_pid):
     wait_for_close(es_pid)
 
 
-# def launch_es():
-#     subprocess.call('emulationstation', shell=True)
-
-
 # functions that handle button events
 def power_switch_off():
     led.blink(.2, .2)

--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -1,30 +1,103 @@
 #!/usr/bin/env python3
+# Safe Shutdown script for Retropie and Retroflag NesPi+ case
 from gpiozero import Button, LED
-import os 
-from signal import pause
+import signal
+import subprocess
+import time
+import os.path
 
-powerPin = 3 
-resetPin = 2 
-ledPin = 14 
-powerenPin = 4 
+powerPin = 3
+resetPin = 2
+ledPin = 14
+powerenPin = 4
 hold = 1
 led = LED(ledPin)
 led.on()
 power = LED(powerenPin)
 power.on()
 
-#functions that handle button events
-def when_pressed():
- led.blink(.2,.2)
- os.system("sudo shutdown -h now")
-def when_released():
- led.on()
-def reboot():
- os.system("sudo reboot")
-  
+
+def get_es_pid():
+    try:
+        output = int(subprocess.check_output(
+            'pgrep -f "^/opt/retropie/supplementary/.*/emulationstation([^.]|$)"',
+            shell=True))
+    except subprocess.CalledProcessError:
+        output = 0
+    return output
+
+
+def get_rc_pid():
+    try:
+        output = int(subprocess.check_output('pgrep -f "^bash .*/runcommand.sh"', shell=True))
+    except subprocess.CalledProcessError:
+        output = 0
+    return output
+
+
+def wait_for_close(process_pid):
+    loop = True
+    while loop:
+        if os.path.exists('/proc/{}'.format(process_pid)):
+            time.sleep(0.1)
+        else:
+            loop = False
+
+
+def close_emulators(process_pid):
+    try:
+        subprocess.call('pkill -TERM -P {}'.format(process_pid), shell=True, timeout=5)
+        wait_for_close(process_pid)
+    except subprocess.TimeoutExpired:
+        subprocess.call('pkill -KILL -P {}'.format(process_pid), shell=True)  # Force close if timeout expires
+        wait_for_close(process_pid)
+
+
+def exit_es(exit_command, es_pid):
+    subprocess.call('touch /tmp/{}'.format(exit_command), shell=True)
+    subprocess.call('chown pi:pi /tmp/{}'.format(exit_command), shell=True)
+    subprocess.call('kill {}'.format(es_pid), shell=True)
+    wait_for_close(es_pid)
+
+
+# def launch_es():
+#     subprocess.call('emulationstation', shell=True)
+
+
+# functions that handle button events
+def power_switch_off():
+    led.blink(.2, .2)
+    es_pid = get_es_pid()
+
+    if es_pid:
+        rc_pid = get_rc_pid()
+        if rc_pid:
+            close_emulators(rc_pid)
+        exit_es('es-shutdown', es_pid)
+    else:
+        subprocess.call('sudo shutdown -h now', shell=True)
+
+
+def power_switch_on():
+    led.on()
+
+
+def reset_pressed():
+    es_pid = get_es_pid()
+
+    if es_pid:
+        rc_pid = get_rc_pid()
+        if rc_pid:
+            close_emulators(rc_pid)
+        exit_es('es-restart', es_pid)
+    else:
+        subprocess.call('sudo reboot', shell=True)
+
+
+# Setup button handlers
 btn = Button(powerPin, hold_time=hold)
 rebootBtn = Button(resetPin)
-rebootBtn.when_pressed = reboot 
-btn.when_pressed = when_pressed
-btn.when_released = when_released
-pause()
+rebootBtn.when_pressed = reset_pressed
+btn.when_pressed = power_switch_off
+btn.when_released = power_switch_on
+signal.pause()


### PR DESCRIPTION
Fixes to the readme file as well as improvements to the Retropie python script  that saves metadata before exit and shuts down emulators and Emulation Station more cleanly.