### PR TITLE
fix shutdown/reboot script

### DIFF
--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -16,11 +16,13 @@ power.on()
 #functions that handle button events
 def when_pressed():
   led.blink(.2,.2)
-  os.system("sudo killall emulationstation && sleep 5s && sudo shutdown -h now")
+  os.system("sudo killall emulationstation")
+  os.system("sleep 5s && sudo shutdown -h now")
 def when_released():
   led.on()
 def reboot(): 
-  os.system("sudo killall emulationstation && sleep 5s && sudo reboot")
+  os.system("sudo killall emulationstation")
+  os.system("sleep 5s && sudo reboot")
   
 btn = Button(powerPin, hold_time=hold)
 rebootBtn = Button(resetPin)


### PR DESCRIPTION
I noticed that the script will not shutdown/reboot the pi if emulationstation isn't running. Here's a change that fixed it for mine.