### PR TITLE
Fix bug: shutdown fails when ES not running

### DIFF
--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -16,11 +16,11 @@ power.on()
 #functions that handle button events
 def when_pressed():
   led.blink(.2,.2)
-  os.system("sudo killall emulationstation && sleep 5s && sudo shutdown -h now")
+  os.system("sudo killall emulationstation ; sleep 5s ; sudo shutdown -h now")
 def when_released():
   led.on()
 def reboot(): 
-  os.system("sudo killall emulationstation && sleep 5s && sudo reboot")
+  os.system("sudo killall emulationstation ; sleep 5s ; sudo reboot")
   
 btn = Button(powerPin, hold_time=hold)
 rebootBtn = Button(resetPin)


### PR DESCRIPTION
This fixes a bug that prevents safe shutdown when EmulationStation is not running.

The os.system() calls use && (logical and) statements, which require each command to return 0 on exit, or the next command won't be run. The "sudo killall emulationstation" fails when ES isn't running, such as when the user has pressed F4 to work at the terminal. Thus the system doesn't shut down. Using simple ";" statements sequences the commands without regard to exit status.