### PR TITLE
use pkill instead of killall to kill emulationstation

### DIFF
--- a/SafeShutdown_gpi.py
+++ b/SafeShutdown_gpi.py
@@ -11,7 +11,7 @@ power.on()
 
 #functions that handle button events
 def when_pressed():
-  os.system("sudo killall emulationstation && sleep 5s && sudo reboot")
+  os.system("sudo pkill -f emulationstation && sleep 5s && sudo reboot")
   
 btn = Button(powerPin, hold_time=hold)
 btn.when_pressed = when_pressed

--- a/SafeShutdown_gpi.py
+++ b/SafeShutdown_gpi.py
@@ -11,7 +11,7 @@ power.on()
 
 #functions that handle button events
 def when_pressed():
-  os.system("sudo pkill -f emulationstation && sleep 5s && sudo reboot")
+  os.system("sudo killall -r emulationstatio* && sleep 5s && sudo reboot")
   
 btn = Button(powerPin, hold_time=hold)
 btn.when_pressed = when_pressed


### PR DESCRIPTION
emulationstation > 15 characters.  This causes an issue
with the latest version of stock retropie (4.6)

using pkill with -f skips the 15 char limit and uses the full process
name