### PR TITLE
use a wildcard for the killall command to support current and legacy versions of retropie

### DIFF
--- a/SafeShutdown_gpi.py
+++ b/SafeShutdown_gpi.py
@@ -11,7 +11,7 @@ power.on()
 
 #functions that handle button events
 def when_pressed():
-  os.system("sudo killall emulationstation && sleep 5s && sudo reboot")
+  os.system("sudo killall -r emulationstatio* && sleep 5s && sudo reboot")
   
 btn = Button(powerPin, hold_time=hold)
 btn.when_pressed = when_pressed


### PR DESCRIPTION
This PR addresses issue #82 

The latest pre-made image of RetroPie, v4.6 – released April 28, 2020, has trouble with the shutdown script.  It appears that the `killall` command fails because the `emulationstation` process is no longer identified by `emulationstation` but instead by its truncated, 15 character name, `emulationstatio`.  
(see more here: https://linux.die.net/man/1/killall, specifically
```
If a command name is longer than 15 characters, the full name may be unavailable (i.e. it is swapped out).
```
I'm not entirely sure what brings about this change, but it's there none the less. 

I first tried to use `pkill` to deal with this but the calling python script hangs and shutdown never occurs.

I next tried shortening the killall to `killall emulationstatio`, but this fails on my `RetroPie 4.4` build which is my current daily driver.

In the end, I settled on using the `-r` flag and wildcarding any characters past the known 15 (`emulationstatio`).  This works correctly on 4.6 and on 4.4.