### PR TITLE
Add pkill -15 signal for retroarch, in order to soft close it and so …

### DIFF
--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -25,6 +25,7 @@ def poweroff():
 	while True:
 		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
 		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
+		os.system("sudo pkill -15 'retroarch'")
 		os.system("sudo killall emulationstation")
 		os.system("sudo killall emulationstatio") #RetroPie 4.6
 		os.system("sudo sleep 5s")
@@ -48,6 +49,7 @@ def reset():
 	while True:
 		#self.assertEqual(GPIO.input(resetPin), GPIO.LOW)
 		GPIO.wait_for_edge(resetPin, GPIO.FALLING)
+		os.system("sudo pkill -15 'retroarch'")
 		os.system("sudo killall emulationstation")
 		os.system("sudo killall emulationstatio") #RetroPie 4.6
 		os.system("sudo sleep 5s")

--- a/SafeShutdown_gpi.py
+++ b/SafeShutdown_gpi.py
@@ -11,6 +11,7 @@ power.on()
 
 #functions that handle button events
 def when_pressed():
+  os.system("sudo pkill -15 'retroarch'")
   os.system("sudo killall emulationstation")
   os.system("sudo killall emulationstatio") #RetroPie 4.6
   os.system("sleep 5s")


### PR DESCRIPTION
…not loosing game save when shutdown or reset without previously exit retorarch via hotkey combo. Proposition for more ergonomic use for kids.