### PR TITLE
fix: wget commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For RetroPie:
 3. Press F4 enter terminal.
 4. In the terminal, type the one-line command below(Case sensitive):
 
-wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/install_gpi.sh" | sudo bash
+    `wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/install_gpi.sh" | sudo bash`
 
 --------------------
 For Recalbox
@@ -18,7 +18,7 @@ For Recalbox
 4. User: root Password: recalboxroot
 5. In the terminal, type the one-line command below(Case sensitive):
 
-wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/recalbox_install_gpi.sh" | bash
+    `wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/recalbox_install_gpi.sh" | bash`
 
 
 
@@ -35,7 +35,7 @@ Example for RetroPie:
 3. Press F4 enter terminal.
 4. In the terminal, type the one-line command below(Case sensitive):
 
-wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/install.sh" | sudo bash
+    `wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/install.sh" | sudo bash`
 
 --------------------
 
@@ -46,7 +46,7 @@ Example for RecalBox:
 4. User: root Password: recalboxroot
 5. In the terminal, type the one-line command below(Case sensitive):
 
-wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/recalbox_install.sh" | bash
+    `wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/recalbox_install.sh" | bash`
 
 --------------------
 
@@ -57,7 +57,7 @@ Example for batocera:
 4. User: root Password: linux
 5. In the terminal, type the one-line command below(Case sensitive):
 
-wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/batocera_install.sh" | bash
+    `wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/batocera_install.sh" | bash`
 
 --------------------
 


### PR DESCRIPTION
The current README formatting makes links appear shortened in browsers in the rendered preview.

This PR marks these commands as code so the URLs stay correct when copy&pasting.