### PR TITLE
Fix shutdown

### DIFF
--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -28,7 +28,7 @@ def poweroff():
 		os.system("sudo killall emulationstation")
 		os.system("sudo killall emulationstatio") #RetroPie 4.6
 		os.system("sudo sleep 5s")
-		os.system("sudo shutdown -r now")
+		os.system("sudo shutdown now")
 
 #blinks the LED to signal button being pushed
 def ledBlink():


### PR DESCRIPTION
Fixes #90 .

Right now the shutdown command is using the `-r` flag, which, when used, actually reboots a system. The correct command should be without that flag. See `man 8 shutdown`.