### PR TITLE
Add scripts and instructions for blast16

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,15 @@ wget -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/b
 
 
 
+### Example for blast16:
+1. Make sure internet connected.
+2. Make sure keyboard connected.
+3. Enter terminal. Press Start, then go to `Options > Tools > Command Line`
+4. In the terminal, type the one-line command below(Case sensitive):
+
+wget --no-check-certificate -O - "https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master/blast16_install.sh" | sudo bash
+
+
+
 ### Example for lakkatv:
 https://github.com/marcelonovaes/lakka_nespi_power

--- a/blast16_SafeShutdown.py
+++ b/blast16_SafeShutdown.py
@@ -1,0 +1,70 @@
+import RPi.GPIO as GPIO
+import os
+import time
+from multiprocessing import Process
+
+#initialize pins
+powerPin = 3 #pin 5
+ledPin = 14 #TXD
+resetPin = 2 #pin 13
+powerenPin = 4 #pin 5
+
+#initialize GPIO settings
+def init():
+	GPIO.setwarnings(False)
+	GPIO.setmode(GPIO.BCM)
+	GPIO.setup(powerPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+	GPIO.setup(resetPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+	GPIO.setup(ledPin, GPIO.OUT)
+	GPIO.output(ledPin, GPIO.HIGH)
+	GPIO.setup(powerenPin, GPIO.OUT)
+	GPIO.output(powerenPin, GPIO.HIGH)
+
+#waits for user to hold button up to 1 second before issuing poweroff command
+def poweroff():
+	while True:
+		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
+		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
+		os.system("/home/pi/blast16/stop.sh")
+		os.system("sudo sleep 5s")
+		os.system("sudo shutdown now")
+
+#blinks the LED to signal button being pushed
+def ledBlink():
+	while True:
+		GPIO.output(ledPin, GPIO.HIGH)
+		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
+		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
+		start = time.time()
+		while GPIO.input(powerPin) == GPIO.LOW:
+			GPIO.output(ledPin, GPIO.LOW)
+			time.sleep(0.2)
+			GPIO.output(ledPin, GPIO.HIGH)
+			time.sleep(0.2)
+
+#resets the pi
+def reset():
+	while True:
+		#self.assertEqual(GPIO.input(resetPin), GPIO.LOW)
+		GPIO.wait_for_edge(resetPin, GPIO.FALLING)
+		os.system("/home/pi/blast16/stop.sh")
+		os.system("sudo sleep 5s")
+		os.system("sudo shutdown -r now")
+
+
+if __name__ == "__main__":
+	#initialize GPIO settings
+	init()
+	#create a multiprocessing.Process instance for each function to enable parallelism 
+	powerProcess = Process(target = poweroff)
+	powerProcess.start()
+	ledProcess = Process(target = ledBlink)
+	ledProcess.start()
+	resetProcess = Process(target = reset)
+	resetProcess.start()
+
+	powerProcess.join()
+	ledProcess.join()
+	resetProcess.join()
+
+	GPIO.cleanup()

--- a/blast16_install.sh
+++ b/blast16_install.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+SourcePath=https://raw.githubusercontent.com/RetroFlag/retroflag-picase/master
+
+#Check if root--------------------------------------
+if [[ $EUID -ne 0 ]]; then
+   echo "Please execute script as root." 
+   exit 1
+fi
+#-----------------------------------------------------------
+
+#RetroFlag pw io ;2:in ;3:in ;4:in ;14:out 1----------------------------------------
+File=/boot/config.txt
+wget --no-check-certificate -O  "/boot/overlays/RetroFlag_pw_io.dtbo" "$SourcePath/RetroFlag_pw_io.dtbo"
+if grep -q "RetroFlag_pw_io" "$File";
+	then
+		sed -i '/RetroFlag_pw_io/c dtoverlay=RetroFlag_pw_io.dtbo' $File 
+		echo "PW IO fix."
+	else
+		echo "dtoverlay=RetroFlag_pw_io.dtbo" >> $File
+		echo "PW IO enabled."
+fi
+if grep -q "enable_uart" "$File";
+	then
+		sed -i '/enable_uart/c enable_uart=1' $File 
+		echo "UART fix."
+	else
+		echo "enable_uart=1" >> $File
+		echo "UART enabled."
+fi
+
+#-----------------------------------------------------------
+
+#Download Python script-----------------------------
+sudo mkdir "/opt/RetroFlag"
+script=/opt/RetroFlag/SafeShutdown.py
+wget --no-check-certificate -O $script "$SourcePath/blast16_SafeShutdown.py"
+
+#Enable Python script to run on start up------------
+RC=/etc/rc.local
+
+if grep -q "sudo python $script &" "$RC";
+	then
+		echo "File $RC already configured. Doing nothing."
+	else
+		sed -i -e "s/^exit 0/sudo python \/opt\/RetroFlag\/SafeShutdown.py \&\n&/g" "$RC"
+		echo "File /etc/rc.local configured."
+fi
+#-----------------------------------------------------------
+
+#Reboot to apply changes----------------------------
+echo "RetroFlag Pi Case installation done. Will now reboot after 3 seconds."
+sleep 3
+sudo reboot
+#-----------------------------------------------------------
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
I found the scripts didn't work correctly for [blast16](http://blast16.tripware.es/) (with the MEGAPi case), probably because the blast16 image is a little old at this point. It fails to connect to GitHub with  `ERROR: The certificate of 'raw.githubusercontent.com' is not yet activated.`

This PR adds a new blast16_install.sh script, a new blast16_SafeShutdown.py script to close blast16's UI nicely, and updates the readme with new instructions.