### PR TITLE
Fix SafeShutdown for NESPi 4 on Raspberry Pi OS (Debian Trixie)

### DIFF
--- a/SafeShutdown.py
+++ b/SafeShutdown.py
@@ -1,72 +1,34 @@
-import RPi.GPIO as GPIO
+from gpiozero import Button, LED
+from signal import pause
 import os
+import threading
 import time
-from multiprocessing import Process
 
-#initialize pins
-powerPin = 3 #pin 5
-ledPin = 14 #TXD
-resetPin = 2 #pin 13
-powerenPin = 4 #pin 5
+POWER_PIN = 3
+RESET_PIN = 2
+LED_PIN = 14
 
-#initialize GPIO settings
-def init():
-	GPIO.setmode(GPIO.BCM)
-	GPIO.setup(powerPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-	GPIO.setup(resetPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-	GPIO.setup(ledPin, GPIO.OUT)
-	GPIO.output(ledPin, GPIO.HIGH)
-	GPIO.setup(powerenPin, GPIO.OUT)
-	GPIO.output(powerenPin, GPIO.HIGH)
-	GPIO.setwarnings(False)
+led = LED(LED_PIN)
+power_btn = Button(POWER_PIN, pull_up=True)
+reset_btn = Button(RESET_PIN, pull_up=True)
 
-#waits for user to hold button up to 1 second before issuing poweroff command
+led.on()
+
+def blink_led():
+    while True:
+        led.off()
+        time.sleep(0.2)
+        led.on()
+        time.sleep(0.2)
+
 def poweroff():
-	while True:
-		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
-		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
-		os.system("sudo killall emulationstation")
-		os.system("sudo killall emulationstatio") #RetroPie 4.6
-		os.system("sudo sleep 5s")
-		os.system("sudo shutdown -r now")
+    threading.Thread(target=blink_led, daemon=True).start()
+    os.system("sudo shutdown -h now")
 
-#blinks the LED to signal button being pushed
-def ledBlink():
-	while True:
-		GPIO.output(ledPin, GPIO.HIGH)
-		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
-		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
-		start = time.time()
-		while GPIO.input(powerPin) == GPIO.LOW:
-			GPIO.output(ledPin, GPIO.LOW)
-			time.sleep(0.2)
-			GPIO.output(ledPin, GPIO.HIGH)
-			time.sleep(0.2)
-
-#resets the pi
 def reset():
-	while True:
-		#self.assertEqual(GPIO.input(resetPin), GPIO.LOW)
-		GPIO.wait_for_edge(resetPin, GPIO.FALLING)
-		os.system("sudo killall emulationstation")
-		os.system("sudo killall emulationstatio") #RetroPie 4.6
-		os.system("sudo sleep 5s")
-		os.system("sudo shutdown -r now")
+    os.system("sudo shutdown -r now")
 
+power_btn.when_pressed = poweroff
+reset_btn.when_pressed = reset
 
-if __name__ == "__main__":
-	#initialize GPIO settings
-	init()
-	#create a multiprocessing.Process instance for each function to enable parallelism 
-	powerProcess = Process(target = poweroff)
-	powerProcess.start()
-	ledProcess = Process(target = ledBlink)
-	ledProcess.start()
-	resetProcess = Process(target = reset)
-	resetProcess.start()
-
-	powerProcess.join()
-	ledProcess.join()
-	resetProcess.join()
-
-	GPIO.cleanup()
+pause()


### PR DESCRIPTION
## Problem

The original script has several bugs that cause unsafe shutdown on modern Raspberry Pi OS (Debian 13 / Trixie):

1. **Wrong shutdown command**: `poweroff()` called `shutdown -r now` (reboot) instead of `shutdown -h now` (halt)
2. **`RPi.GPIO` incompatible**: Newer Pi OS uses `lgpio` backend — `GPIO.wait_for_edge()` on GPIO 2/3 (I2C pins) raises `lgpio.error: 'bad event request'`, crashing the service
3. **Unsafe shutdown timing**: `os.system("sudo sleep 5s")` delayed the shutdown call by 5s — NESPi 4 can cut power in that window, causing hard power loss
4. **`os.system("sudo sleep 5s")` antipattern**: Spawns shell+sudo just to sleep; should use `time.sleep()` in Python

## Fix

- Replace `RPi.GPIO` with `gpiozero` (works correctly on Debian 13 Trixie with `lgpio` backend)
- Fix `poweroff()` to call `shutdown -h now`
- Call `shutdown -h now` immediately on button press — let systemd handle graceful service teardown before NESPi 4 cuts power
- LED blinks on power press to signal shutdown in progress

## Tested on

- **Hardware**: NESPi 4 Case + Raspberry Pi 4
- **OS**: Raspberry Pi OS / Debian GNU/Linux 13 (Trixie)
- **Kernel**: 6.18.29+rpt-rpi-v8